### PR TITLE
Add link to Gazebo Ionic

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -39,6 +39,7 @@
       <li><a href="?distribution=fortress">Fortress</a></li>
       <li><a href="?distribution=garden">Garden</a></li>
       <li><a href="?distribution=harmonic">Harmonic</a></li>
+      <li><a href="?distribution=ionic">Ionic</a></li>
     </ul>
 
     <ul>


### PR DESCRIPTION
I already updated the configuration file but still need an html link to the Gazebo Ionic view.

Follow up to #27.

This should add a link to the following:

* https://osrf.github.io/osr_dashboard/?distribution=ionic